### PR TITLE
Jackson 2.11: adding public setters for deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wix.restaurants</groupId>
     <artifactId>wix-restaurants-availability-all</artifactId>
-    <version>1.10.0-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Wix Restaurants Availability</name>
     <description>Wix Restaurants Availability modules pom</description>

--- a/wix-restaurants-availability-api/pom.xml
+++ b/wix-restaurants-availability-api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.wix.restaurants</groupId>
         <artifactId>wix-restaurants-availability-all</artifactId>
-        <version>1.10.0-SNAPSHOT</version>
+        <version>1.11.0-SNAPSHOT</version>
     </parent>
 
 

--- a/wix-restaurants-availability-api/src/main/java/com/wix/restaurants/availability/DateTimeWindow.java
+++ b/wix-restaurants-availability-api/src/main/java/com/wix/restaurants/availability/DateTimeWindow.java
@@ -43,7 +43,17 @@ public class DateTimeWindow implements Serializable, Cloneable {
 
     /** Default constructor for JSON deserialization. */
     public DateTimeWindow() {}
-    
+
+    /** Start setter for JSON deserialization. */
+    public void setStart(Date start) {
+        this.start = start;
+    }
+
+    /** End setter for JSON deserialization. */
+    public void setEnd(Date end) {
+        this.end = end;
+    }
+
     @Override
 	public DateTimeWindow clone() {
     	return new DateTimeWindow(

--- a/wix-restaurants-availability-utils/pom.xml
+++ b/wix-restaurants-availability-utils/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.wix.restaurants</groupId>
         <artifactId>wix-restaurants-availability-all</artifactId>
-        <version>1.10.0-SNAPSHOT</version>
+        <version>1.11.0-SNAPSHOT</version>
     </parent>
 
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>com.wix.restaurants</groupId>
 			<artifactId>wix-restaurants-availability-api</artifactId>
-			<version>1.10.0-SNAPSHOT</version>
+			<version>1.11.0-SNAPSHOT</version>
 		</dependency>
 
         <!-- Test Dependencies -->


### PR DESCRIPTION
Jackson 2.11 fails to deserialize `DateTimeWindow` because it tries to use available public methods for `start` and `end` properties, which have incompatible parameters:
```java
public Calendar start(TimeZone tz) {
   // ...
}
public Calendar end(TimeZone tz) {
   // ...
}
```

This PR fixes this problem by introducing standard setters.

https://github.com/wix-private/server-infra/issues/17896